### PR TITLE
[FIX] pos_loyalty: keep reward lines on a finalized order

### DIFF
--- a/addons/pos_loyalty/__manifest__.py
+++ b/addons/pos_loyalty/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': "Point of Sale - Coupons & Loyalty",
-    'version': '2.0',
+    'version': '2.0.1',
     'category': 'Sales/Point Of Sale',
     'sequence': 6,
     'summary': 'Use Coupons, Gift Cards and Loyalty programs in Point of Sale',

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -96,6 +96,11 @@ patch(PaymentScreen.prototype, {
             return agg;
         }, {});
         for (const line of rewardLines) {
+            if (!line.coupon_id) {
+                // Reward line of an order reloaded from the server (e.g. after
+                // an online payment) may have no local coupon to confirm.
+                continue;
+            }
             const reward = reward_by_id[line.reward_id];
             if (!couponData[line.coupon_id]) {
                 couponData[line.coupon_id] = {

--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -418,6 +418,13 @@ patch(Order.prototype, {
      * Refreshes the currently applied rewards, if they are not applicable anymore they are removed.
      */
     _updateRewardLines() {
+        // A finalized order (e.g. reloaded from the server after an online
+        // payment) holds the rewards that were actually applied and saved.
+        // Refreshing them would drop them, because their coupon is no longer
+        // in the local cache, so keep them untouched.
+        if (["paid", "done", "invoiced"].includes(this.state)) {
+            return;
+        }
         if (!this.orderlines.length) {
             return;
         }


### PR DESCRIPTION
`https://github.com/odoo/odoo/pull/270216`

Steps to reproduce:
- Install pos_loyalty + pos_online_payment.
- Configure an automatic discount program (e.g. 1% off the order) and an online payment method.
- In the POS, add a customer eligible for the program and a product so the
  discount reward line is added automatically.
- Pay the order with the online payment method and let the customer pay.

Issue:
The receipt printed right after the online payment is missing the loyalty
discount line: the total is shown without the discount while the amount actually paid is the discounted amount, so the ticket looks underpaid. Re-printing the order later shows the correct total. With a loyalty program
that also gives points, confirming the order additionally raises:
    ValueError: invalid literal for int() with base 10: 'false'

Cause:
After a successful online payment the order is rebuilt from the data saved
on the server and selected again. Selecting an order triggers `_updateRewards`, which calls `_updateRewardLines` to refresh the applied
rewards. On this rebuilt order the reward lines reference a coupon that is
no longer in the local cache (its `coupon_id` comes back as `false` for "current" programs that don't persist a coupon), so `_updateRewardLines` removes them and cannot re-apply them. The order then displays a wrong total, and `_postPushOrderResolve` sends that `false` coupon id to `confirm_coupon_programs`, which fails when casting the key to an int.

The order is already paid and saved: its reward lines are authoritative and
must not be recomputed.

Fix:
- `_updateRewardLines`: do nothing on a finalized order (paid/done/invoiced)
  so the rewards saved on the server are kept as-is.
- `_postPushOrderResolve`: skip reward lines that have no coupon, so no invalid coupon id is sent to `confirm_coupon_programs`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
