### PR TITLE
[FIX] stock: avoid O(n²) move-line scan when reserving serial products

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1539,7 +1539,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         # Find a candidate move line to update or create a new one.
         serial_move_line_vals = []
         for reserved_quant, quantity in quants:
-            to_update = next((line for line in self.move_line_ids if line._reservation_is_updatable(quantity, reserved_quant)), False)
+            to_update = False if self.product_id.tracking == 'serial' else next((line for line in self.move_line_ids if line._reservation_is_updatable(quantity, reserved_quant)), False)
             if to_update:
                 uom_quantity = self.product_id.uom_id._compute_quantity(quantity, to_update.product_uom_id, rounding_method='HALF-UP')
                 uom_quantity = float_round(uom_quantity, precision_digits=rounding)


### PR DESCRIPTION
_update_reserved_quantity searches for an updatable move line per reserved quant via `next(l for l in self.move_line_ids if l._reservation_is_updatable(..))`. This scans the (growing) move_line_ids for every quant → O(n²) on a move of n serial units. But stock.move.line._reservation_is_updatable returns False unconditionally for tracking == 'serial', so the scan can never find a candidate and is pure waste.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
