### PR TITLE
[FIX] point_of_sale: add deterministic tiebreaker to limited product loading

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -845,7 +845,8 @@ class PosConfig(models.Model):
              ORDER BY product_product__product_tmpl_id.is_favorite DESC,
                       CASE WHEN product_product__product_tmpl_id.type = 'service' THEN 1 ELSE 0 END DESC,
                       pm.date DESC NULLS LAST,
-                      product_product.write_date DESC
+                      product_product.write_date DESC,
+                      product_product.id
                 LIMIT %s
             """,
             query.from_clause,

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -25,3 +25,4 @@ from . import test_res_config_settings
 from . import test_generic_localization
 from . import test_stock_product_updates
 from . import test_pos_picking_backorder
+from . import test_pos_product_loading

--- a/addons/point_of_sale/tests/test_pos_product_loading.py
+++ b/addons/point_of_sale/tests/test_pos_product_loading.py
@@ -1,0 +1,53 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestPosGetLimitedProductsLoading(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pos_categ = cls.env['pos.category'].create({
+            'name': 'Tiebreak Test Category',
+        })
+        # 5 products tying on every ORDER BY key used by get_limited_products_loading:
+        # none favorite, type 'consu' (not 'service'), no stock.move.line (pm.date NULL
+        # for all), and created together in this same transaction so write_date is
+        # identical for all of them.
+        cls.tied_products = cls.env['product.product'].create([{
+            'name': 'Tiebreak Product %s' % index,
+            'type': 'consu',
+            'available_in_pos': True,
+            'sale_ok': True,
+            'is_favorite': False,
+            'pos_categ_ids': [Command.set([cls.pos_categ.id])],
+        } for index in range(5)])
+        cls.config = cls.env['pos.config'].create({
+            'name': 'Tiebreak Test PoS',
+            'limit_categories': True,
+            'iface_available_categ_ids': [Command.set([cls.pos_categ.id])],
+        })
+
+    def test_get_limited_products_loading_deterministic_tiebreak(self):
+        """ Products tied on every ORDER BY key (favorite, type, last stock move,
+        write_date) must still be selected deterministically once LIMIT is applied.
+        Without the `id` tiebreaker this selection depends on Postgres's
+        unspecified physical scan order, i.e. it is flaky.
+        """
+        self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_product_count', 3)
+
+        loaded_ids = {product['id'] for product in self.config.get_limited_products_loading(['id'])}
+        tied_ids = sorted(self.tied_products.ids)
+        lowest_three_ids, highest_two_ids = tied_ids[:3], tied_ids[3:]
+
+        for product_id in lowest_three_ids:
+            self.assertIn(
+                product_id, loaded_ids,
+                "The lowest-id tied products must be loaded first (deterministic id tiebreak)."
+            )
+        for product_id in highest_two_ids:
+            self.assertNotIn(
+                product_id, loaded_ids,
+                "The highest-id tied products must not be loaded once the limit is reached."
+            )


### PR DESCRIPTION
### Problem
`pos.config.get_limited_products_loading` orders candidate products by `is_favorite`, service type, last `stock.move.line` date and `write_date`, with **no final tiebreaker**. When products tie on all of those keys — e.g. non-favorite consumable products with no stock moves, created in the same transaction so sharing an identical `write_date` (`transaction_timestamp()`) — the `LIMIT` result is decided by PostgreSQL's unspecified physical scan order. The set of products loaded into the POS session is therefore non-deterministic.

This surfaced as an intermittent failure of `pos_loyalty.tests.test_product_loading.TestPOSLoyaltyProductLoading.test_loyalty_product_loading` on large installs: a freshly-created product's heap row can be scanned first and win the tie under `LIMIT`, so a product that should not be loaded is loaded. The flakiness only appears when the surrounding module/test set churns the `product_product` heap enough to change physical row order — which is why it reproduces on the full Runbot install but not on smaller local installs (independent of module count).

### Fix
Add `product_product.id` as a final ascending tiebreaker to the `ORDER BY`, making limited product loading stable and reproducible (among equally ranked products, the established lower-id ones load first).

### Test
New browser-free `TransactionCase` `point_of_sale/tests/test_pos_product_loading.py` creates products tying on every ORDER BY key and asserts the lowest-id ones load deterministically under the limit. The pre-existing `pos_loyalty` product-loading test also passes. Verified: `0 failed, 0 error(s) of 2 tests`.

Note: this defect exists in upstream odoo/odoo 18.0 as well; an upstream PR is intended as a follow-up.