### PR TITLE
[FIX] pos_loyalty: earn loyalty points on POS orders paid online

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -359,7 +359,10 @@ patch(Order.prototype, {
             return;
         }
 
-        updateRewardsMutex.exec(() => {
+        // Return the mutex promise so callers can await the recompute (e.g. after an
+        // online payment, before confirming the coupon programs). `set_order` still
+        // calls this without awaiting, which is fine.
+        return updateRewardsMutex.exec(() => {
             return this._updateLoyaltyPrograms().then(async () => {
                 // Try auto claiming rewards
                 const claimableRewards = this.getClaimableRewards(false, false, true);

--- a/addons/pos_online_payment/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/app/screens/payment_screen/payment_screen.js
@@ -263,6 +263,17 @@ patch(PaymentScreen.prototype, {
             }
         }
 
+        // The order was rebuilt from the server data and re-selected above, which drops
+        // the client-side loyalty `couponPointChanges` and schedules an async reward
+        // recompute (`set_order` -> `_updateRewards`) that `set_order` does NOT await.
+        // Wait for that recompute to finish before confirming the coupon programs,
+        // otherwise the earned points are confirmed as empty. Most visible for a
+        // first-time customer whose loyalty card must be fetched with an extra RPC, so
+        // the recompute never wins the race on its own.
+        if (this.currentOrder._updateRewards) {
+            await this.currentOrder._updateRewards();
+        }
+
         await this.postPushOrderResolve([this.currentOrder.server_id]);
 
         this.afterOrderValidation(true);


### PR DESCRIPTION
`https://github.com/odoo/odoo/pull/276813`

Steps to reproduce:
- Install pos_loyalty + pos_online_payment.
- Configure a nominative "loyalty" program (trigger=auto, applies_on=both) that awards points, and an online payment method.
- In the POS, add a first-time eligible customer + a product, then pay the order with the online payment method and let the customer pay.

Issue:
The customer earns no loyalty points (no loyalty.card is even created for a first-time buyer). Cash orders work. The loss is intermittent for customers whose card is already cached.

Cause:
After a successful online payment the order is rebuilt from the server data, which does not carry the client-side `couponPointChanges`, then re-selected.
`set_order` schedules an async `_updateRewards()` recompute but does NOT await it, and `afterPaidOrderSavedOnServer` immediately calls `postPushOrderResolve`, so `confirm_coupon_programs` reads an empty `couponPointChanges`. A first-time buyer additionally needs an async `fetchLoyaltyCard` RPC, so the recompute can never win the race.

Fix:
- `_updateRewards`: return the mutex promise so it can be awaited.
- `afterPaidOrderSavedOnServer`: await the reward recompute before confirming the coupon programs.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
