### PR TITLE
[IMP] point_of_sale: hide decimals for integer quantities on receipts

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -68,12 +68,16 @@ export class PosOrderline extends Base {
 
         if (unit) {
             if (unit.rounding) {
-                const decimals = this.models["decimal.precision"].find(
-                    (dp) => dp.name === "Product Unit of Measure"
-                ).digits;
-                qtyStr = formatFloat(this.qty, {
-                    digits: [69, decimals],
-                });
+                if (this.qty % 1 === 0) {
+                    qtyStr = this.qty.toFixed(0);
+                } else {
+                    const decimals = this.models["decimal.precision"].find(
+                        (dp) => dp.name === "Product Unit of Measure"
+                    ).digits;
+                    qtyStr = formatFloat(this.qty, {
+                        digits: [69, decimals],
+                    });
+                }
             } else {
                 qtyStr = this.qty.toFixed(0);
             }


### PR DESCRIPTION
Bốc một phần logic từ `https://github.com/odoo/odoo/commit/456a7428f8e352c968c9cd3f3b79a17a0121d5cf`

Quantities were always formatted with the global 'Product Unit of Measure' decimal precision, so a quantity of 1 was displayed as 1.000 (with a 3-digit precision) on the order screen and the printed receipt, even for countable units such as Units/Piece.

Backport the Odoo 19 behavior: whole-number quantities are displayed without a decimal part, while fractional quantities (e.g. 1.5 kg) keep the standard precision-based formatting.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
