### PR TITLE
[IMP] point_of_sale: hide decimals for integer quantities on receipts

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -672,9 +672,13 @@ export class Orderline extends PosModel {
                 var decimals = this.pos.dp["Product Unit of Measure"];
                 var rounding = Math.max(unit.rounding, Math.pow(10, -decimals));
                 this.quantity = round_pr(quant, rounding);
-                this.quantityStr = formatFloat(this.quantity, {
-                    digits: [69, decimals],
-                });
+                if (this.quantity % 1 === 0) {
+                    this.quantityStr = this.quantity.toFixed(0);
+                } else {
+                    this.quantityStr = formatFloat(this.quantity, {
+                        digits: [69, decimals],
+                    });
+                }
             } else {
                 this.quantity = round_pr(quant, 1);
                 this.quantityStr = this.quantity.toFixed(0);


### PR DESCRIPTION
Bốc một phần logic từ `https://github.com/odoo/odoo/commit/456a7428f8e352c968c9cd3f3b79a17a0121d5cf`

Quantities were always formatted with the global 'Product Unit of Measure' decimal precision, so a quantity of 1 was displayed as 1.000 (with a 3-digit precision) on the order screen and the printed receipt, even for countable units such as Units/Piece.

Backport the Odoo 19 behavior: whole-number quantities are displayed without a decimal part, while fractional quantities (e.g. 1.5 kg) keep the standard precision-based formatting.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
