### PR TITLE
[FIX] website: deflake snippet_empty_parent_autoremove tour

### DIFF
--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -5,7 +5,14 @@ import wTourUtils from "@website/js/tours/tour_utils";
 function removeSelectedBlock() {
     return {
         content: "Remove selected block",
-        trigger: '#oe_snippets we-customizeblock-options:nth-last-child(3) .oe_snippet_remove',
+        // The customize panel is rebuilt asynchronously (behind the edition
+        // mutex) after every selection change or removal, and the stale panel
+        // of the previous selection has the same shape as the fresh one, so a
+        // bare :nth-last-child(3) can match the stale panel while its editor
+        // is being destroyed and the click is then silently swallowed. Every
+        // use of this helper removes a "Column" block and the stale panel of
+        // its parent snippet has no such block, so scope the match to it.
+        trigger: '#oe_snippets we-customizeblock-options:nth-last-child(3):has(we-title:contains("Column")) .oe_snippet_remove',
     };
 }
 
@@ -24,6 +31,14 @@ wTourUtils.registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
         trigger: 'iframe #wrap .s_text_image .row > :nth-child(2)',
     },
     removeSelectedBlock(),
+    {
+        // The second column and its options panel are removed in the same
+        // synchronous block of removeSnippet, so once the column has left the
+        // iframe DOM the stale "Column" panel is guaranteed to be gone.
+        content: "Wait for the second column to be removed",
+        trigger: 'iframe #wrap .s_text_image .row > :first-child:last-child',
+        isCheck: true,
+    },
     {
         content: "Click on first column",
         trigger: 'iframe #wrap .s_text_image .row > :first-child',


### PR DESCRIPTION
For Odoo `https://github.com/odoo/odoo/pull/280226`

The customize panel is rebuilt asynchronously (behind the edition mutex) after every selection change or removal, and the stale panel of the previous selection has the same shape as the fresh one. The bare :nth-last-child(3) trigger of 'Remove selected block' can match the stale panel while its editor is being destroyed; the click is then silently swallowed, the column stays in place and the tour times out on 'Check that #wrap is empty' on loaded hosts.

Scope the remove trigger to a panel actually showing the Column options (every use of the helper removes a Column block and the stale panel of its parent snippet has no such block), and wait for the second column to leave the iframe DOM before selecting the first one - the column and its options panel are removed in the same synchronous block of removeSnippet, so this guarantees the stale panel is gone.

Reproduced on a stock database under host load (2/3 failures with stepDelay=0); consistently green with this change.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
