### PR TITLE
[FIX] point_of_sale: adapt tour helper to integer quantity display

### DIFF
--- a/addons/point_of_sale/static/tests/tours/helpers/generic_components/OrderWidgetMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/generic_components/OrderWidgetMethods.js
@@ -42,6 +42,7 @@ export function hasLine({
         trigger += `:has(.product-name:contains("${productName}"))`;
     }
     if (quantity) {
+        quantity = parseFloat(quantity) % 1 === 0 ? parseInt(quantity).toString() : quantity;
         trigger += `:has(em.qty:contains("${quantity}"))`;
     }
     if (price) {


### PR DESCRIPTION
Commit bf677a9c7e08 backported the Odoo 19 behavior of displaying whole-number quantities without a decimal part, but the tour helper still compared the raw expected quantity string ('1.0'/'1.00') against the rendered '1', breaking every orderline check step across the POS test suites (runbot 223649). Normalize the expected quantity the same way upstream does in 456a7428f8e3 (order_widget_util.js).





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
