### PR TITLE
[FIX] point_of_sale: adapt tour helper to integer quantity display

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/generic_components/order_widget_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/generic_components/order_widget_util.js
@@ -39,6 +39,7 @@ export function hasLine({
         trigger += `:has(.product-name:contains("${productName}"))`;
     }
     if (quantity) {
+        quantity = parseFloat(quantity) % 1 === 0 ? parseInt(quantity).toString() : quantity;
         trigger += `:has(.qty:contains("${quantity}"))`;
     }
     if (price) {


### PR DESCRIPTION
Commit c63e34ff56fa backported the Odoo 19 behavior of displaying whole-number quantities without a decimal part, but the tour helper still compared the raw expected quantity string ('1.0'/'1.00') against the rendered '1', breaking every orderline check step across the POS test suites. Normalize the expected quantity the same way upstream does in 456a7428f8e3 (order_widget_util.js).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
