### PR TITLE
[FIX] pos_sale: assert every sale picking is cancelled, not a single one

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -968,7 +968,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrder4', login="accountman")
 
-        self.assertEqual(sale_order.picking_ids.state, 'cancel')
+        self.assertEqual(set(sale_order.picking_ids.mapped('state')), {'cancel'})
         self.assertEqual(sale_order.pos_order_line_ids.order_id.picking_ids.state, 'assigned')
         self.assertEqual(self.env['purchase.order.line'].search_count([('product_id', '=', product_a.id)]), 1)
 

--- a/addons/repair/static/tests/tours/repair_order.js
+++ b/addons/repair/static/tests/tours/repair_order.js
@@ -16,7 +16,11 @@ registry.category("web_tour.tours").add('test_repair_without_product_in_parts', 
     {
         content: "Click partner field",
         trigger: ".o_field_widget[name=partner_id] input",
-        run: "click",
+        // Type the partner name: the customer search mode of the field orders
+        // the dropdown by customer_rank, so on a database with enough ranked
+        // customers a bare click would not show "A Partner" (rank 0) in the
+        // first page at all.
+        run: "edit A Partner",
     },
     // Note: Selecting the partner is only to trigger the compute;
     // this could be done by modifying any other field.


### PR DESCRIPTION
test_settle_order_with_multistep_delivery_receipt reads sale_order.picking_ids.state, assuming the order carries exactly one delivery picking. With the foreign-trade export flow installed, the NL test partner makes the order route its delivery through the customs zone, so two chain pickings exist by the time the POS settles the order — both correctly cancelled — and the singleton access raises "Expected singleton: stock.picking(588, 587)".

Assert the actual intent of the test instead ("all the picking are cancelled", per its docstring): the order has pickings and every one of them is cancelled. Still passes on a bare community stack.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
