### PR TITLE
[FIX] pos_loyalty: stabilize customer loading in tours

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -120,6 +120,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.product_b.uom_id = 1
 
+    def start_tour(self, *args, **kwargs):
+        partner_count = self.env['res.partner'].sudo().with_context(active_test=False).search_count([])
+        # Keep ORM-created tour partners in the initial preload despite unrelated demo data.
+        self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_customer_count', partner_count)
+        return super().start_tour(*args, **kwargs)
+
     def create_programs(self, details):
         """
         Create loyalty programs based on the details given.


### PR DESCRIPTION
Fix test-only cho CI regression lộ ra khi [tvtmaaddons PR 14493](https://github.com/Viindoo/tvtmaaddons/pull/14493) bật lại cụm freight ở 19.0: cụm này nạp **117 bản ghi đối tác danh mục** (sân bay, cảng biển, ICD, hãng vận chuyển) ngay khi cài, trong khi màn hình điểm bán chỉ nạp trước **100** khách hàng - nên khách hàng do chính loyalty tour tạo ra bị đẩy ra ngoài danh sách.

```mermaid
flowchart TD
    A[Cài bất kỳ module freight nào] --> B[Kéo theo cụm logistics: 117 đối tác danh mục vào CSDL]
    B --> C[Cả 117 đều chưa có đơn điểm bán nào]
    C --> D{Khách hàng do tour tạo có lọt vào 100 suất nạp trước?}
    D -- "trước: không, 117 lớn hơn 100 nên hết suất" --> E[Tour dừng ở bước chọn khách - FAIL]
    E --> F[Assertion loyalty không được chạy]
    D -- "sau: có, cận nạp lấy theo danh mục thực tế" --> G[Tour chọn được khách - OK]
    G --> H[Kiểm chứng loyalty và hoàn tiền như cũ]
```

<details>
<summary><b>Vấn đề &amp; hệ quả</b></summary>

Màn hình chọn khách của điểm bán chỉ nạp sẵn một số lượng khách hàng có hạn, ưu tiên ai mua nhiều nhất tại quầy, rồi mới xếp theo tên. Cụm freight nạp sẵn danh mục nghiệp vụ của mình - sân bay, cảng biển, kho ICD, hãng vận chuyển - và những bản ghi này cũng nằm chung một bảng đối tác. **Lý do:** chúng chưa từng phát sinh đơn tại quầy nên xếp ngang nhau, và chỉ riêng số lượng của chúng đã vượt hạn mức nạp sẵn.

**Hệ quả:** loyalty browser tour tự tạo khách hàng rồi chọn khách đó trên giao diện, nhưng khách vừa tạo cũng chưa có đơn nào nên phải tranh suất theo tên - và không còn suất. Runbot dừng ngay ở bước chọn khách, nên toàn bộ assertion loyalty phía sau **không hề được kiểm tra**: lưới bảo vệ mất đi trong im lặng chứ không báo sai nghiệp vụ.

Đây là coupling giữa dữ liệu danh mục của một module không liên quan và test của core. Cần nói rõ: đây **không phải** dữ liệu demo - danh mục nêu trên được nạp trong mọi lần cài, kể cả cài không demo.

</details>

<details>
<summary><b>Cách tái hiện</b></summary>

Data setup:

1. Điều kiện hệ thống: cơ sở dữ liệu có nhiều đối tác chưa phát sinh đơn điểm bán nào - đủ để vượt hạn mức nạp sẵn của màn hình chọn khách. **Không cần bật dữ liệu demo.**
2. Cài `pos_loyalty` cùng bất kỳ module freight nào trong [tvtmaaddons PR 14493](https://github.com/Viindoo/tvtmaaddons/pull/14493). Một module freight kéo theo cả cụm qua chuỗi phụ thuộc `viin_freight_management` → `viin_logistics_account` → `viin_logistics`.
3. Chạy bộ test `TestUi` của `pos_loyalty` trên cài đặt đó.

Thao tác và kết quả:

4. Tour tự tạo khách hàng `Refunding Guy` bằng ORM, mở điểm bán rồi chọn khách đó trên giao diện.
5. **Trước fix:** khách hàng rơi ra ngoài lượt nạp sẵn nên tour hết giờ chờ ngay ở bước chọn khách, assertion hoàn tiền `30` điểm chưa kịp chạy. **Sau fix:** khách hàng nằm trong lượt nạp sẵn, tour vẫn đi qua giao diện thật và giữ nguyên assertion đó.

### Đối tác danh mục được nạp là master data, không phải demo

Cụm freight nạp 117 bản ghi `res.partner` từ khối `data` của manifest, tức có mặt trong mọi lần cài:

| File | Nội dung | Bản ghi |
| --- | --- | --- |
| `viin_logistics/data/res_partner_sea_port_data.xml` | Cảng biển | 56 |
| `viin_freight_air/data/res_partner_airport_data.xml` | Sân bay | 27 |
| `viin_freight_air/data/res_partner_carrier_data.xml` | Hãng vận chuyển | 17 |
| `viin_freight_management/data/res_partner_icd_data.xml` | Kho ICD | 11 |
| `viin_freight_management/data/res_partner_data.xml` | Đối tác nghiệp vụ khác | 6 |
| | **Tổng** | **117** |

`DEFAULT_LIMIT_LOAD_PARTNER` của `point_of_sale` là `100`, nên riêng master data đã lấp kín lượt nạp sẵn.

### Bằng chứng công khai: ba test chết ở đúng bước chọn khách

Runbot build [224238](https://runbot.viindoo.com/runbot/build/19-0-9-10-upg-freight-transport-modes-and-consolidation-18-0-to-19-0-224238) của chính [tvtmaaddons PR 14493](https://github.com/Viindoo/tvtmaaddons/pull/14493) dựng core từ nhánh `19.0` chứ không phải từ nhánh PR này, nên đúng là trạng thái *chưa có fix*. Subbuild `407882` kết thúc `3 failed, 0 error(s) of 1376 tests`:

| Test method | Browser tour | Điểm chết chính xác |
| --- | --- | --- |
| `TestUi.test_not_create_loyalty_card_expired_program` | `test_not_create_loyalty_card_expired_program` | Step 8/26, không tìm được `Test Partner` trong danh sách khách. |
| `TestUi.test_not_create_loyalty_card_max_usage_program` | `PosOrderClaimReward` | Step 8/33, không tìm được `Test Partner` trong danh sách khách. |
| `TestUi.test_refund_does_not_decrease_points` | `test_refund_does_not_decrease_points` | Step 8/42, không tìm được `Refunding Guy`; assertion `card.points == 30` chưa chạy. |

Log cài đặt của build đó (subbuild `407879`) xác nhận không có dữ liệu demo nào tham gia: `3103` dòng `odoo.modules.loading: loading <module>/<file>` cho khối `data`, và **`0`** dòng `Module <name>: loading demo`. Cùng một logger, cùng mức INFO - nên đây không phải chuyện log bị lọc. Năm file master data ở bảng trên đều xuất hiện trong log này.

Cả ba test chết ở cùng một bước và cùng một nguyên nhân, nên phần dưới chỉ kể một luồng.

</details>

<details>
<summary><b>Giải pháp</b></summary>

Ngay trước mỗi loyalty browser tour, test lấy quy mô danh mục đối tác hiện tại làm cận cho lượt nạp sẵn. Nhờ vậy khách hàng do tour tạo không bị loại chỉ vì một module khác nạp danh mục nghiệp vụ của nó. Tour, URL, người dùng đăng nhập và mọi assertion nghiệp vụ đều giữ nguyên.

Hạn mức nạp sẵn mà người dùng điểm bán nhận trong production **không đổi**: cận chỉ được đặt trong phạm vi transaction của test và biến mất khi test kết thúc.

Phạm vi của PR này dừng ở chỗ gỡ phụ thuộc-dữ-liệu-ngoài-scope ra khỏi tour của `pos_loyalty`. Cách `point_of_sale` xếp hạng đối tác khi nạp sẵn - hiện chỉ theo số đơn tại quầy rồi đến tên, không phân biệt đối tác nào thực sự là khách hàng - là câu hỏi sản phẩm riêng, thuộc `point_of_sale`, và không giải trong PR này.

</details>

<details>
<summary><b>Lợi ích</b></summary>

- Module hợp lệ nạp được danh mục nghiệp vụ của mình mà không làm loyalty tour của core chết theo thứ tự dữ liệu.
- Ba test tiếp tục xác minh hành vi giao diện thật và assertion loyalty, thay vì dừng lại ở bước chọn khách.
- Cận nạp sẵn tính theo danh mục thực tế tại thời điểm chạy - không hard-code tên khách hàng, ID hay một con số nạp sẵn cố định.
- Không đụng code production: toàn bộ diff nằm trong file test của `pos_loyalty`.

</details>

<details>
<summary><b>Đã làm</b></summary>

- `addons/pos_loyalty/tests/test_frontend.py`: `TestUi.start_tour()` đặt `point_of_sale.limited_customer_count` bằng số bản ghi `res.partner` hiện có (kể cả bản ghi đã lưu trữ), rồi forward nguyên lời gọi sang `start_tour` gốc. Override đặt ở `TestUi` của `pos_loyalty` chứ không ở `HttpCase` dùng chung, nên chỉ tour của module này chịu ảnh hưởng.
- Nguồn regression: [tvtmaaddons PR 14493](https://github.com/Viindoo/tvtmaaddons/pull/14493). Điều kiện kích hoạt là **master data** của cụm freight (khối `data` của manifest), không phải dữ liệu demo - xem bảng 117 bản ghi ở phần Cách tái hiện.
- Bằng chứng trạng thái chưa-fix: runbot build [224238](https://runbot.viindoo.com/runbot/build/19-0-9-10-upg-freight-transport-modes-and-consolidation-18-0-to-19-0-224238), subbuild `407882` - `3 failed, 0 error(s) of 1376 tests`, đúng ba test nêu trên; subbuild `407879` chứng minh không có demo data.

</details>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
