### PR TITLE
[FIX] pos_restaurant: wait for the order sync instead of racing it

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -758,12 +758,27 @@ registry.category("web_tour.tours").add("test_book_and_release_table", {
             {
                 content: "Check if order has a server ID",
                 trigger: "body",
-                run: () => {
-                    const order = posmodel.models["pos.order"].getFirst();
-
-                    if (typeof order.id !== "number") {
-                        throw new Error("Order does not have a valid server ID");
+                // `waitForLoading()` above only waits for the loader to disappear; it does
+                // not await the `syncAllOrders` RPC that gives the order its server id.
+                // Sampling the id once therefore races that RPC, and which side wins is
+                // decided by how fast the runner is - the step passes on a quick machine
+                // and fails on a slow or contended one. Poll until the id arrives instead,
+                // and only fail once it has genuinely not arrived.
+                // The usual Odoo idiom for a racy tour step is a more specific `trigger`,
+                // letting the tour engine's own retry loop do the waiting (see 8cb86ec07ad5
+                // "[FIX] lunch: fix non-determistic tour error"). That does not transfer
+                // here: the condition is JS model state, not a DOM fact, so there is no
+                // selector to wait on.
+                async run() {
+                    const deadline = Date.now() + 10000;
+                    while (Date.now() < deadline) {
+                        const order = posmodel.models["pos.order"].getFirst();
+                        if (typeof order?.id === "number") {
+                            return;
+                        }
+                        await new Promise((resolve) => setTimeout(resolve, 50));
                     }
+                    throw new Error("Order does not have a valid server ID");
                 },
             },
             FloorScreen.clickTable("5"),


### PR DESCRIPTION
## Problem

The `Check if order has a server ID` step of the `test_book_and_release_table` tour samples the
order's id exactly once and throws if it is not yet a number. Nothing sequences that sample after
the `syncAllOrders` RPC that assigns the id:

- the preceding `waitForLoading()` waits only for `body:not(:has(.loader))`, which knows nothing
  about the RPC;
- the step's own `trigger: "body"` matches immediately.

So whether the step passes is decided by whether the server happens to answer first.

On Viindoo runbot it does not. Subbuild **407980**:

```
02:05:36,110  [7/10] Tour test_book_and_release_table → Step Check if order has a server ID
02:05:36,152  PoS synchronisation #52520204 ... created pos.order #563
02:05:36,177  FAILED: ... Error: Order does not have a valid server ID
```

The assertion lost by **42 ms**. The order itself was created fine.

## This is hardware speed, not module load

Measured across **24 runs at four addons-path scales** - 58, 126, 293 and **1330** installed
modules (the last exceeding runbot's own 1089):

| installed modules | delta (step − order_created), 3 runs | mean |
|---|---|---|
| 58 | +79 / +87 / +93 ms | +86.3 |
| 126 | +71 / +81 / +84 ms | +78.7 |
| 293 | +76 / +54 / +86 ms | +72.0 |
| 1330 | +65 / +60 / +72 ms | +65.7 |

Positive = server won. A **23x** growth in installed modules moved the mean by only ~24%, well
inside the single-stage spread. Registry size, POS asset-bundle weight and third-party POS addons
were each ruled out; what differs is how fast the machine is. Any slow or contended runner can lose
this race.

## Fix

Poll for the id with a deadline instead of sampling once, so the step waits for the sync it depends
on. The thrown error string is unchanged, so existing log triage still matches.

The usual idiom for a non-deterministic tour step is a more specific `trigger`, letting the tour
engine's retry loop do the waiting - see 8cb86ec07ad5 *"[FIX] lunch: fix non-determistic tour
error"*. That does not transfer here: the condition is JS model state (`posmodel`'s `pos.order`
id), not a DOM fact, so there is no selector to wait on.

## Verification

The race is *won* on the development machine, so a natural failure cannot be reproduced there. The
failure was therefore constructed, by injecting a 400 ms sleep into `pos.order.sync_from_ui`:

| # | injected delay | tour | result | delta | reached |
|---|---|---|---|---|---|
| 1 | 400 ms | unfixed | **FAIL** | −360 ms | dies at `[7/10]` |
| 2 | 400 ms | **fixed** | **PASS** | −320 ms | `[10/10]`, `tour succeeded` |
| 3 | none | **fixed** | **PASS** | **+86 ms** | `[10/10]` |

Run 1 reproduces the runbot signature exactly - `FAILED: [7/10] Tour test_book_and_release_table →
Step Check if order has a server ID` / `Error: Order does not have a valid server ID`.

Runs 1 and 2 share an identically slow server (−360 vs −320 ms is noise); the only variable is the
fix. Run 3 returns to the natural baseline band. Chrome attached in every run and no `SkipTest`
occurred, so these are real tour executions.

The rest of the `pos_restaurant` suite is unaffected: 0 failed, 0 errors. The single skip,
`test_13_crm_team`, needs `pos_sale` and is pre-existing.

## Note

This tour has not actually been executing on Viindoo runbot: an override set
`CHECK_BROWSER_ITERATIONS = 1`, giving Chrome 0.1 s to report its DevTools port, so every tour
raised `unittest.SkipTest` and reported green. Reverting that override (Viindoo/tvtmaaddons#14456)
is what surfaced this failure. It is not a regression from that PR - it is a pre-existing condition
the PR revealed.